### PR TITLE
Set default method to just read file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,28 @@ module.exports = function(grunt) {
           }
         },
         src: ['test/fixtures/*.html']
+      },
+
+      external_sources_txt: {
+        options: {
+          subject: 'external_sources_txt',
+          message: {
+            subject: 'external_sources_txt',
+            text: 'test fallback txt'
+          }
+        },
+        src: ['test/fixtures/email-body-as-txt.txt']
+      },
+
+      external_sources_md: {
+        options: {
+          subject: 'external_sources_md',
+          message: {
+            subject: 'external_sources_md',
+            text: 'test fallback md'
+          }
+        },
+        src: ['test/fixtures/*.md']
       }
     },
 

--- a/tasks/nodemailer.js
+++ b/tasks/nodemailer.js
@@ -101,12 +101,7 @@ module.exports = function(grunt) {
 
           ext = path.extname(f);
 
-          if (ext === '.txt') {
-
-            newMsg = _.clone(defaultMessage);
-            newMsg.text = grunt.file.read(f);
-
-          } else if (/^\.html?$/i.test(ext)) {
+          if (/^\.html?$/i.test(ext)) {
 
             newMsg = _.clone(defaultMessage);
             newMsg.html = grunt.file.read(f);
@@ -122,6 +117,9 @@ module.exports = function(grunt) {
               newMsg.text = grunt.file.read(txtFile);
             }
 
+          } else {
+            newMsg = _.clone(defaultMessage);
+            newMsg.text = grunt.file.read(f);
           }
 
         }

--- a/test/fixtures/email-body-as-md.md
+++ b/test/fixtures/email-body-as-md.md
@@ -1,0 +1,1 @@
+this.is.the.text.md

--- a/test/fixtures/email-body-as-txt.txt
+++ b/test/fixtures/email-body-as-txt.txt
@@ -1,0 +1,1 @@
+this.is.the.text.txt

--- a/test/nodemailer_test.js
+++ b/test/nodemailer_test.js
@@ -55,7 +55,6 @@ exports.nodemailer = {
 
     test.expect(5);
 
-
     var actual = grunt.file.readJSON('tmp/another_subject');
     var actualFallback = grunt.file.readJSON('tmp/test_with_fallback');
 
@@ -68,7 +67,29 @@ exports.nodemailer = {
 
     test.done();
 
+  },
+
+  external_sources_txt: function (test) {
+
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/external_sources_txt');
+
+    test.ok(actual.message.indexOf('Subject: external_sources_txt') !== -1, 'Default title tag');
+    test.ok(actual.message.indexOf('this.is.the.text.txt') !== -1, 'Text is loaded from path');
+
+    test.done();
+  },
+
+  external_sources_md: function (test) {
+
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/external_sources_md');
+
+    test.ok(actual.message.indexOf('Subject: external_sources_md') !== -1, 'Default title tag');
+    test.ok(actual.message.indexOf('this.is.the.text.md') !== -1, 'Text is loaded from path');
+
+    test.done();
   }
-
-
 };


### PR DESCRIPTION
We had a text file that had extension ".md" which we wanted to send as plain text.
